### PR TITLE
add doggostruct to the fun whitelist

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -19,6 +19,7 @@ class Fun(commands.Cog):
             1280331315115327488, # Celica's Office
             1272185726699573358, # Nnin's Corner
             140529276175777792, # Nova's personal discord
+            949981074153435157, # Doggostruct
         ]
         self.pasta_command_ran = False
         self.bubblewrap_command_ran = False


### PR DESCRIPTION
My guild's been asking for it, so i'd like to add Doggostruct to the fun-allowed servers